### PR TITLE
update hyperparameters of bayeisan net

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(name='gryffin',
             "seaborn==0.11.1",
             "SQLAlchemy==1.4.6",
             "tensorflow==2.4.0",
-            "tensorflow-probability==0.12.0"
+            "tensorflow-probability==0.11.0"
         ],
         python_requires='>=3.6',
 )

--- a/src/gryffin/bayesian_network/model_details.py
+++ b/src/gryffin/bayesian_network/model_details.py
@@ -5,7 +5,7 @@ __author__ = 'Florian Hase'
 #========================================================================
 
 model_details = {
-                'num_epochs':  2 * 10**3, 'learning_rate': 0.05,
+                'num_epochs':  2 * 10**3, 'learning_rate': 0.01,
                 'burnin': 0, 'thinning': 1, 'num_draws': 10**3,
 
                 'num_layers': 3, 'hidden_shape': 6,

--- a/src/gryffin/bayesian_network/tfprob_interface/tfprob_interface.py
+++ b/src/gryffin/bayesian_network/tfprob_interface/tfprob_interface.py
@@ -220,7 +220,8 @@ class TfprobNetwork(object):
 
                     target = tf.cast(self.y[:, kernel_begin : kernel_end], tf.int32)
 
-                    prior_temperature = 0.5 + 10.0 / self.num_obs
+#                    prior_temperature = 0.5 + 10.0 / self.num_obs
+                    prior_temperature = 1.0
 #                                       prior_temperature = 0.4
                     post_temperature  = prior_temperature
 

--- a/src/gryffin/bayesian_network/tfprob_interface/tfprob_interface.py
+++ b/src/gryffin/bayesian_network/tfprob_interface/tfprob_interface.py
@@ -220,9 +220,7 @@ class TfprobNetwork(object):
 
                     target = tf.cast(self.y[:, kernel_begin : kernel_end], tf.int32)
 
-#                    prior_temperature = 0.5 + 10.0 / self.num_obs
                     prior_temperature = 1.0
-#                                       prior_temperature = 0.4
                     post_temperature  = prior_temperature
 
                     prior_support = prior_relevant


### PR DESCRIPTION
Small changes to the hyperparameters of the bayesian network. I noticed we were sampling duplicate parameters with the multiple sampling strategies, which is a result of `nans` generated in the calculation resulting in the rewards being the same. 

Both of these param changes smooth out the continuous approximation to the categorical dist and removes this issue. 

